### PR TITLE
Release 3.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,13 @@ matrix:
         - UNICODE_WIDTH=16
     - os: linux
       env:
+        - MB_PYTHON_VERSION=3.4
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+        - PLAT=i686
+    - os: linux
+      env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP="1.9.3"
         - NP_TEST_DEP="1.9.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
     PACKAGE_NAME: tables
     BUILD_COMMIT: v3.4.1
     BUILD_DEPENDS: "hdf5 numpy>=1.8.0 numexpr>=2.5.2 six cython bzip2"
-    TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six"
+    TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six>=1.9.0 mock"
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker
     WHEELHOUSE_UPLOADER_SECRET:
         secure:

--- a/config.sh
+++ b/config.sh
@@ -1,7 +1,7 @@
 # Define custom utilities
 # Test for OSX with [ -n "$IS_OSX" ]
 LZO_VERSION=2.09
-BLOSC_VERSION=1.10.2
+#BLOSC_VERSION=${BLOSC_VERSION:-1.10.2}
 
 function build_wheel {
     local repo_dir=${1:-$REPO_DIR}
@@ -13,7 +13,8 @@ function build_wheel {
 }
 
 function build_libs {
-    build_blosc
+    # Do not build blosc: Use built-in (issue: gh-5)
+    #build_blosc
     build_bzip2
     build_lzo
     build_hdf5
@@ -28,7 +29,8 @@ function build_linux_wheel {
     if [ -z "$(readelf --dynamic $bad_lib | grep RUNPATH)" ]; then
         patchelf --set-rpath $(dirname $bad_lib) $bad_lib
     fi
-    build_pip_wheel $@
+    export CFLAGS="$CFLAGS -std=gnu99"
+    build_bdist_wheel $@
 }
 
 function build_osx_wheel {
@@ -37,7 +39,7 @@ function build_osx_wheel {
     # Build dual arch wheel
     export CC=clang
     export CXX=clang++
-    brew install pkg-config
+    install_pkg_config
     # 32-bit wheel
     export CFLAGS="-arch i386"
     export CXXFLAGS="$CFLAGS"


### PR DESCRIPTION
New wheels for v3.4.1:

- [x] re-add python 3.4 manylinux wheels: on request (Ubuntu 14 LTS still ships python 3.4)
- [x] try to fix OSX builds (multibuild `install_pkg_config`)
- [x] disable building BLOSC on Linux/OSX: Try to use built-in BLOSC (#5)
