### PR TITLE
Build v3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 env:
     global:
         - REPO_DIR=pytables
-        - BUILD_COMMIT=v3.5.2   # Remember to update this for every new PyTables release!
+        - BUILD_COMMIT=v3.6.0 # Remember to update this for every new PyTables release!
         - PLAT=x86_64
         - UNICODE_WIDTH=32
         - NP_BUILD_DEP=1.9.3
         - NP_TEST_DEP=1.9.3
-        - HDF5_VERSION=1.10.4
+        - HDF5_VERSION=1.10.5
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
         # Following generated with
         # travis encrypt -r MacPython/h5py-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
@@ -28,29 +28,6 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP="1.11.3"
         - NP_TEST_DEP="1.11.3"
@@ -71,16 +48,6 @@ matrix:
         - PLAT=i686
         - NP_BUILD_DEP="1.14.5"
         - NP_TEST_DEP="1.14.5"
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP="1.9.3"
-        - NP_TEST_DEP="1.9.3"
     - os: osx
       language: generic
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,30 +2,18 @@ environment:
   global:
     REPO_DIR: pytables
     PACKAGE_NAME: tables
-    BUILD_COMMIT: v3.5.2   # Remember to update this for every new PyTables release!
+    BUILD_COMMIT: v3.6.0  # Remember to update this for every new PyTables release!
     BUILDWHEEL: "True"  # trigger setup.py to include zlib.dll
     BUILD_DEPENDS: "hdf5 numpy>=1.9.3 numexpr>=2.6.2 six cython bzip2"
     TEST_DEPENDS: "numpy>=1.9.3 numexpr>=2.6.2 six>=1.9.0 mock"
     DISABLE_AVX2: "True"  # do not include AVX2 in this build
-    HDF5_VERSION: 1.10.4
+    HDF5_VERSION: 1.10.5
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker
     WHEELHOUSE_UPLOADER_SECRET:
         secure:
             9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
 
   matrix:
-    - PYTHON: "C:\\Miniconda"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Miniconda-x64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Miniconda35"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
     - PYTHON: "C:\\Miniconda36"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "32"


### PR DESCRIPTION
Drop Python 2.7 (not supported)
Drop Python 3.5 (following numpy NEP 29)